### PR TITLE
Setup ocamlformat and format all files

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -32,5 +32,8 @@
   (alcotest (and (>= 1.1.0) :with-test))
   (alcotest-lwt (and (>= 1.1.0) :with-test))
   (yojson (and (>= 1.7.0) :with-test))
+
+  ;; Dev dependencies
+  (ocamlformat :dev)
  )
 )

--- a/letters.opam
+++ b/letters.opam
@@ -23,6 +23,7 @@ depends: [
   "alcotest" {>= "1.1.0" & with-test}
   "alcotest-lwt" {>= "1.1.0" & with-test}
   "yojson" {>= "1.7.0" & with-test}
+  "ocamlformat" {dev}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/lib/letters.ml
+++ b/lib/letters.ml
@@ -1,11 +1,11 @@
 type config = {
-    sender: string;
-    username: string;
-    password: string;
-    hostname: string;
-    port: int option;
-    with_starttls: bool;
-    ca_dir: string;
+  sender : string;
+  username : string;
+  password : string;
+  hostname : string;
+  port : int option;
+  with_starttls : bool;
+  ca_dir : string;
 }
 
 type body = Plain of string | Html of string
@@ -14,30 +14,45 @@ type recipient = To of string | Cc of string | Bcc of string
 
 let stream_of_string s =
   let once = ref false in
-  (fun () -> if !once then None else ( once := true ; Some (s, 0, String.length s)))
+  fun () ->
+    if !once then None
+    else (
+      once := true;
+      Some (s, 0, String.length s) )
 
-let str_to_colombe_address str_address = match Emile.of_string str_address with
-  | Ok mailbox -> (match Colombe_emile.to_forward_path mailbox with
+let str_to_colombe_address str_address =
+  match Emile.of_string str_address with
+  | Ok mailbox -> (
+      match Colombe_emile.to_forward_path mailbox with
       | Ok address -> address
-      | Error _ -> failwith (Printf.sprintf "Invalid email address: %s" str_address))
+      | Error _ ->
+          failwith (Printf.sprintf "Invalid email address: %s" str_address) )
   | Error _ -> failwith (Printf.sprintf "Invalid email address: %s" str_address)
 
 let domain_of_reverse_path = function
   | None -> Rresult.R.error_msgf "reverse-path is empty"
-  | Some { Colombe.Path.domain= domain; _ } -> Ok domain
+  | Some { Colombe.Path.domain; _ } -> Ok domain
 
-let to_recipient_to_address : recipient -> Mrmime.Address.t option = fun recipient -> match recipient with
-  | To address -> (match Mrmime.Mailbox.of_string address with
+let to_recipient_to_address : recipient -> Mrmime.Address.t option =
+ fun recipient ->
+  match recipient with
+  | To address -> (
+      match Mrmime.Mailbox.of_string address with
       | Ok mailbox -> Some (Mrmime.Address.mailbox mailbox)
-      | Error _ -> failwith (Fmt.strf "Invalid email address for 'to': %s" address))
+      | Error _ ->
+          failwith (Fmt.strf "Invalid email address for 'to': %s" address) )
   | Cc _ -> None
   | Bcc _ -> None
 
-let cc_recipient_to_address : recipient -> Mrmime.Address.t option = fun recipient -> match recipient with
+let cc_recipient_to_address : recipient -> Mrmime.Address.t option =
+ fun recipient ->
+  match recipient with
   | To _ -> None
-  | Cc address -> (match Mrmime.Mailbox.of_string address with
+  | Cc address -> (
+      match Mrmime.Mailbox.of_string address with
       | Ok mailbox -> Some (Mrmime.Address.mailbox mailbox)
-      | Error _ -> failwith (Fmt.strf "Invalid email address for 'to': %s" address))
+      | Error _ ->
+          failwith (Fmt.strf "Invalid email address for 'to': %s" address) )
   | Bcc _ -> None
 
 let load_directory path =
@@ -54,14 +69,14 @@ let load_file path =
   Lwt.return (Bytes.unsafe_to_string raw)
 
 let certs_of_pem path =
-  let ( <.> ) f g = fun x -> f (g x) in
+  let ( <.> ) f g x = f (g x) in
   let open Lwt.Infix in
   load_file path
   >|= (X509.Certificate.decode_pem <.> Cstruct.of_string)
   >|= Rresult.R.get_ok
 
-let certs_of_pem_directory ?(ext= "crt") path =
-  let ( <.> ) f g = fun x -> f (g x) in
+let certs_of_pem_directory ?(ext = "crt") path =
+  let ( <.> ) f g x = f (g x) in
   let open Lwt.Infix in
   load_directory path
   >>= Lwt_list.filter_p (Lwt.return <.> Fpath.has_ext ext)
@@ -73,95 +88,121 @@ let build_email ~from ~recipients ~subject ~body =
   let open Mrmime in
   let subject = Unstructured.Craft.v subject in
   let date = Date.of_ptime ~zone:Date.Zone.GMT (Ptime_clock.now ()) in
-  let from_addr = match Mailbox.of_string from with
+  let from_addr =
+    match Mailbox.of_string from with
     | Ok v -> v
     | Error _ -> failwith "Invalid email address for 'from'"
   in
   let to_addresses = List.filter_map to_recipient_to_address recipients in
   let cc_addresses = List.filter_map cc_recipient_to_address recipients in
   let headers =
-    Field.(Field (Field_name.subject, Unstructured, subject))
-    :: Field.(Field (Field_name.date, Date, date))
-    :: Field.(Field (Field_name.from, Mailbox, from_addr))
-    :: Field.(Field (Field_name.v "To", Addresses, to_addresses))
-    :: Field.(Field (Field_name.cc, Addresses, cc_addresses))
-    :: []
+    [
+      Field.(Field (Field_name.subject, Unstructured, subject));
+      Field.(Field (Field_name.date, Date, date));
+      Field.(Field (Field_name.from, Mailbox, from_addr));
+      Field.(Field (Field_name.v "To", Addresses, to_addresses));
+      Field.(Field (Field_name.cc, Addresses, cc_addresses));
+    ]
   in
   let plain_text_headers =
     let content1 =
       let open Content_type in
-      make `Text (Subtype.v `Text "plain") Parameters.(of_list [ k "charset", v "utf-8" ])
+      make `Text
+        (Subtype.v `Text "plain")
+        Parameters.(of_list [ (k "charset", v "utf-8") ])
     in
-    Header.of_list Field.[
-        Field (Field_name.content_type, Content, content1);
-        Field (Field_name.content_encoding, Encoding, `Quoted_printable)
-      ]
+    Header.of_list
+      Field.
+        [
+          Field (Field_name.content_type, Content, content1);
+          Field (Field_name.content_encoding, Encoding, `Quoted_printable);
+        ]
   in
   let html_headers =
     let content1 =
       let open Content_type in
-      make `Text (Subtype.v `Text "html") Parameters.(of_list [ k "charset", v "utf-8" ])
+      make `Text
+        (Subtype.v `Text "html")
+        Parameters.(of_list [ (k "charset", v "utf-8") ])
     in
-    Header.of_list Field.[
-        Field (Field_name.content_type, Content, content1);
-        Field (Field_name.content_encoding, Encoding, `Quoted_printable)
-      ]
+    Header.of_list
+      Field.
+        [
+          Field (Field_name.content_type, Content, content1);
+          Field (Field_name.content_encoding, Encoding, `Quoted_printable);
+        ]
   in
-  let body = match body with
+  let body =
+    match body with
     | Plain text -> Mt.part ~header:plain_text_headers (stream_of_string text)
     | Html text -> Mt.part ~header:html_headers (stream_of_string text)
   in
   Mt.make (Mrmime.Header.of_list headers) Mt.simple body
 
 let send ~config:c ~recipients:r ~message:m =
-  let (let*) = Lwt.bind in
-  let authentication: Sendmail.authentication = {
-    username = c.username;
-    password = c.password;
-    mechanism = Sendmail.PLAIN
-  } in
-  let port = match c.port, c.with_starttls with
+  let ( let* ) = Lwt.bind in
+  let authentication : Sendmail.authentication =
+    { username = c.username; password = c.password; mechanism = Sendmail.PLAIN }
+  in
+  let port =
+    match (c.port, c.with_starttls) with
     | None, true -> 587
     | None, false -> 465
     | Some v, _ -> v
   in
   let mail = Mrmime.Mt.to_stream m in
-  let from_mailbox = match Emile.of_string c.sender with
+  let from_mailbox =
+    match Emile.of_string c.sender with
     | Ok v -> v
     | Error `Invalid -> failwith "Invalid sender address"
   in
-  let from_addr = match Colombe_emile.to_reverse_path from_mailbox with
+  let from_addr =
+    match Colombe_emile.to_reverse_path from_mailbox with
     | Ok v -> v
-    | Error `Msg msg -> failwith msg
+    | Error (`Msg msg) -> failwith msg
   in
-  let recipients = List.map (fun recipient -> (match recipient with
-      | To a -> a
-      | Cc a -> a
-      | Bcc a -> a) |> str_to_colombe_address) r
+  let recipients =
+    List.map
+      (fun recipient ->
+        (match recipient with To a -> a | Cc a -> a | Bcc a -> a)
+        |> str_to_colombe_address)
+      r
   in
-  let domain = match domain_of_reverse_path from_addr with
+  let domain =
+    match domain_of_reverse_path from_addr with
     | Ok v -> v
     | Error _ -> failwith "Failed to extract domain of sender address"
   in
-  let hostname = match Domain_name.of_string c.hostname with
+  let hostname =
+    match Domain_name.of_string c.hostname with
     | Error _ -> failwith "Config hostname is not valid hostname"
-    | Ok hostname -> match Domain_name.host hostname with
-      | Error _ -> failwith "Config hostname is not valid hostname"
-      | Ok hostname -> hostname
+    | Ok hostname -> (
+        match Domain_name.host hostname with
+        | Error _ -> failwith "Config hostname is not valid hostname"
+        | Ok hostname -> hostname )
   in
-  let* certs = match Fpath.of_string c.ca_dir with
-    | Ok path -> (certs_of_pem_directory ~ext:"pem" path)
+  let* certs =
+    match Fpath.of_string c.ca_dir with
+    | Ok path -> certs_of_pem_directory ~ext:"pem" path
     | Error _ -> failwith "Failed to open CA certificates directory"
   in
   let tls_authenticator = X509.Authenticator.chain_of_trust ~time:now certs in
-  if c.with_starttls
-  then
-    let* res = Sendmail_handler.run_with_starttls ~hostname ~port ~domain ~authentication ~tls_authenticator ~from:from_addr ~recipients ~mail in
+  if c.with_starttls then
+    let* res =
+      Sendmail_handler.run_with_starttls ~hostname ~port ~domain ~authentication
+        ~tls_authenticator ~from:from_addr ~recipients ~mail
+    in
     match res with
     | Ok () -> Lwt.return (Ok ())
-    | Error err -> Lwt.fail_with (Fmt.str "Sending email failed, %a" Sendmail_with_tls.pp_error err)
+    | Error err ->
+        Lwt.fail_with
+          (Fmt.str "Sending email failed, %a" Sendmail_with_tls.pp_error err)
   else
-    let* res = Sendmail_handler.run ~hostname ~port ~domain ~authentication ~tls_authenticator ~from:from_addr ~recipients ~mail in
+    let* res =
+      Sendmail_handler.run ~hostname ~port ~domain ~authentication
+        ~tls_authenticator ~from:from_addr ~recipients ~mail
+    in
     match res with
     | Ok () -> Lwt.return (Ok ())
-    | Error err -> Lwt.fail_with (Fmt.str "Sending email failed, %a" Sendmail.pp_error err)
+    | Error err ->
+        Lwt.fail_with (Fmt.str "Sending email failed, %a" Sendmail.pp_error err)

--- a/lib/letters.mli
+++ b/lib/letters.mli
@@ -1,12 +1,11 @@
-
 type config = {
-    sender: string;
-    username: string;
-    password: string;
-    hostname: string;
-    port: int option;
-    with_starttls: bool;
-    ca_dir: string;
+  sender : string;
+  username : string;
+  password : string;
+  hostname : string;
+  port : int option;
+  with_starttls : bool;
+  ca_dir : string;
 }
 
 type body = Plain of string | Html of string
@@ -14,14 +13,14 @@ type body = Plain of string | Html of string
 type recipient = To of string | Cc of string | Bcc of string
 
 val build_email :
-  from: string ->
-  recipients: recipient list ->
-  subject: string ->
-  body: body ->
+  from:string ->
+  recipients:recipient list ->
+  subject:string ->
+  body:body ->
   Mrmime.Mt.t
 
 val send :
-  config: config ->
-  recipients: recipient list ->
-  message: Mrmime.Mt.t ->
+  config:config ->
+  recipients:recipient list ->
+  message:Mrmime.Mt.t ->
   (unit, string) Lwt_result.t

--- a/lib/sendmail_handler.ml
+++ b/lib/sendmail_handler.ml
@@ -1,6 +1,6 @@
-module Lwt_scheduler = Colombe.Sigs.Make(Lwt)
+module Lwt_scheduler = Colombe.Sigs.Make (Lwt)
 
-let ( <.> ) f g = fun x -> f (g x)
+let ( <.> ) f g x = f (g x)
 
 let lwt_bind x f =
   let open Lwt.Infix in
@@ -8,55 +8,78 @@ let lwt_bind x f =
   inj (prj x >>= (prj <.> f))
 
 let lwt =
-  { Colombe.Sigs.bind= lwt_bind
-  ; return= (fun x -> Lwt_scheduler.inj (Lwt.return x)) }
+  {
+    Colombe.Sigs.bind = lwt_bind;
+    return = (fun x -> Lwt_scheduler.inj (Lwt.return x));
+  }
 
-type flow =
-  { ic : Lwt_io.input_channel
-  ; oc : Lwt_io.output_channel }
+type flow = { ic : Lwt_io.input_channel; oc : Lwt_io.output_channel }
 
 let rdwr =
-  { Colombe.Sigs.rd= (fun { ic; _ } bytes off len ->
+  {
+    Colombe.Sigs.rd =
+      (fun { ic; _ } bytes off len ->
         let res = Lwt_io.read_into ic bytes off len in
-        Lwt_scheduler.inj res)
-  ; wr= (fun { oc; _ } bytes off len ->
-        let res = Lwt_io.write_from_exactly oc (Bytes.unsafe_of_string bytes) off len in
-        Lwt_scheduler.inj res) }
+        Lwt_scheduler.inj res);
+    wr =
+      (fun { oc; _ } bytes off len ->
+        let res =
+          Lwt_io.write_from_exactly oc (Bytes.unsafe_of_string bytes) off len
+        in
+        Lwt_scheduler.inj res);
+  }
 
-let run_with_starttls ~hostname ?port ~domain ~authentication ~tls_authenticator ~from ~recipients ~mail =
+let run_with_starttls ~hostname ?port ~domain ~authentication ~tls_authenticator
+    ~from ~recipients ~mail =
   let port = match port with Some port -> port | None -> 465 in
   let tls = Tls.Config.client ~authenticator:tls_authenticator () in
   let ctx = Sendmail_with_tls.Context_with_tls.make () in
   let open Lwt.Infix in
-
   Lwt_unix.gethostbyname (Domain_name.to_string hostname) >>= fun res ->
-  if Array.length res.Lwt_unix.h_addr_list = 0
-  then Lwt.fail_with (Fmt.strf "%a can not be resolved" Domain_name.pp hostname)
+  if Array.length res.Lwt_unix.h_addr_list = 0 then
+    Lwt.fail_with (Fmt.strf "%a can not be resolved" Domain_name.pp hostname)
   else
     let socket = Lwt_unix.socket Lwt_unix.PF_INET Unix.SOCK_STREAM 0 in
-    Lwt_unix.connect socket (Lwt_unix.ADDR_INET (res.Lwt_unix.h_addr_list.(0), port)) >>= fun () ->
-
+    Lwt_unix.connect socket
+      (Lwt_unix.ADDR_INET (res.Lwt_unix.h_addr_list.(0), port))
+    >>= fun () ->
     let closed = ref false in
-    let close () = if !closed then Lwt.return () else ( closed := true ; Lwt_unix.close socket ) in
+    let close () =
+      if !closed then Lwt.return ()
+      else (
+        closed := true;
+        Lwt_unix.close socket )
+    in
     let ic = Lwt_io.of_fd ~close ~mode:Lwt_io.Input socket in
     let oc = Lwt_io.of_fd ~close ~mode:Lwt_io.Output socket in
 
-    let mail_stream = fun () -> match mail () with
+    let mail_stream () =
+      match mail () with
       | Some v -> Lwt_scheduler.inj (Lwt.return (Some v))
       | None -> Lwt_scheduler.inj (Lwt.return None)
     in
 
-    let fiber = Sendmail_with_tls.sendmail lwt rdwr { ic; oc; } ctx tls ~authentication ~domain from recipients mail_stream in
+    let fiber =
+      Sendmail_with_tls.sendmail lwt rdwr { ic; oc } ctx tls ~authentication
+        ~domain from recipients mail_stream
+    in
     Lwt_scheduler.prj fiber
 
-let run ~hostname ?port ~domain ~authentication ~tls_authenticator ~from ~recipients ~mail =
+let run ~hostname ?port ~domain ~authentication ~tls_authenticator ~from
+    ~recipients ~mail =
   let ( let* ) = Lwt.bind in
   let port = match port with Some port -> port | None -> 465 in
   let ctx = Colombe.State.Context.make () in
-  let* (ic, oc) = Tls_lwt.connect tls_authenticator ((Domain_name.to_string hostname), port) in
-  let mail_stream = fun () -> match mail () with
+  let* ic, oc =
+    Tls_lwt.connect tls_authenticator (Domain_name.to_string hostname, port)
+  in
+  let mail_stream () =
+    match mail () with
     | Some v -> Lwt_scheduler.inj (Lwt.return (Some v))
     | None -> Lwt_scheduler.inj (Lwt.return None)
   in
-  let fiber = Sendmail.sendmail lwt rdwr { ic; oc; } ctx ~authentication ~domain from recipients mail_stream in
+  let fiber =
+    Sendmail.sendmail lwt rdwr { ic; oc } ctx ~authentication ~domain from
+      recipients mail_stream
+  in
   Lwt_scheduler.prj fiber

--- a/lib/sendmail_handler.mli
+++ b/lib/sendmail_handler.mli
@@ -1,22 +1,21 @@
-
 val run_with_starttls :
-  hostname: 'a Domain_name.t ->
+  hostname:'a Domain_name.t ->
   ?port:int ->
   domain:Colombe.Domain.t ->
   authentication:Sendmail.authentication ->
   tls_authenticator:X509.Authenticator.t ->
   from:Colombe.Reverse_path.t ->
   recipients:Colombe.Forward_path.t list ->
-  mail: Mrmime.Mt.buffer Mrmime.Mt.stream ->
+  mail:Mrmime.Mt.buffer Mrmime.Mt.stream ->
   (unit, Sendmail_with_tls.error) Lwt_result.t
 
 val run :
-  hostname: 'a Domain_name.t ->
+  hostname:'a Domain_name.t ->
   ?port:int ->
   domain:Colombe.Domain.t ->
   authentication:Sendmail.authentication ->
   tls_authenticator:X509.Authenticator.t ->
   from:Colombe.Reverse_path.t ->
   recipients:Colombe.Forward_path.t list ->
-  mail: Mrmime.Mt.buffer Mrmime.Mt.stream ->
+  mail:Mrmime.Mt.buffer Mrmime.Mt.stream ->
   (unit, Sendmail.error) Lwt_result.t


### PR DESCRIPTION
Ocamlformat brings opinionated formatting so we can skip syntax discussions and focus on things that matter. It also does a great job simplifying code, making it easier to contribute for new OCaml devs. 