### PR TITLE
Feature/allow unauthenticated

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This will use port `587`, uses STARTTLS for encryption and tries automatically f
 
 Port `587` is default when using STARTTLS. If you set `~with_starttls:false`, then the default port will be `465`.
 
-This library does **not** support SMTP connections without TLS encryption or authentication. For TLS encryption, this library uses [ocaml-tls](https://opam.ocaml.org/packages/tls/).
+This library does **not** support SMTP connections without TLS encryption. For TLS encryption, this library uses [ocaml-tls](https://opam.ocaml.org/packages/tls/).
 
 If you want to change the server port you can do it with `Config.set_port` (passing `None` causes default port to be used):
 
@@ -243,16 +243,16 @@ To create temporary *ethereal.email* account and store the account details, you 
 curl -s -d '{ "requestor": "letters", "version": "dev" }' "https://api.nodemailer.com/user" -X POST -H "Content-Type: application/json" | jq '{ hostname: .smtp.host, port: .smtp.port, secure: false, username: .user, password: .pass, }'> ethereal_account.json
 ```
 
-For *mailtrap.io*, you need to create a personal account first and get the API key:
+For *mailtrap.io*, you need to create a personal account first and get the API key (for v1 API):
 - [signup](https://mailtrap.io/register/signup?ref=header)
-- [copy API token from Settings](https://mailtrap.io/settings)
+- click on your name top right and select "My Profile", copy the "Api Token"
 
 The configuration file you can create with following steps:
 - create environment variable containing your API token: `export MAILTRAP_API_TOKEN=<API token>`
 - run the following one-liner in terminal to create the configuration file:
 
 ``` shell
-curl -s -H "Authorization: Bearer ${MAILTRAP_API_TOKEN}" "https://mailtrap.io/api/v1/inboxes" | jq '.[0] | { hostname: .domain, port: .smtp_ports[2], secure: false, username: .username, password: .password }' > mailtrap_account.json
+curl -s -H "Api-Token: ${MAILTRAP_API_TOKEN}" "https://mailtrap.io/api/v1/inboxes" | jq '.[0] | { hostname: .domain, port: .smtp_ports[2], secure: false, username: .username, password: .password }' > mailtrap_account.json
 ```
 
 Now you are ready to execute these tests. You can run them with the following command:

--- a/lib/letters.ml
+++ b/lib/letters.ml
@@ -5,8 +5,8 @@ module Config = struct
     | Detect
 
   type t =
-    { username : string
-    ; password : string
+    { username : string option
+    ; password : string option
     ; hostname : string
     ; port : int option
     ; with_starttls : bool
@@ -183,8 +183,11 @@ let send =
   fun ~config:c ~sender ~recipients ~message ->
     let open Config in
     let ( let* ) = Lwt.bind in
-    let authentication : Sendmail.authentication =
-      { username = c.username; password = c.password; mechanism = Sendmail.PLAIN }
+    let authentication : Sendmail.authentication option =
+      match c.username, c.password with
+      | Some username, Some password ->
+        Some { username; password; mechanism = Sendmail.PLAIN }
+      | _ -> None
     in
     let port =
       match c.port, c.with_starttls with
@@ -252,7 +255,7 @@ let send =
           ~hostname
           ~port
           ~domain
-          ~authentication
+          ?authentication
           ~tls_authenticator:tls_peer_verifier
           ~from:from_addr
           ~recipients
@@ -269,7 +272,7 @@ let send =
           ~hostname
           ~port
           ~domain
-          ~authentication
+          ?authentication
           ~tls_authenticator:tls_peer_verifier
           ~from:from_addr
           ~recipients

--- a/lib/letters.mli
+++ b/lib/letters.mli
@@ -6,16 +6,18 @@ module Config : sig
 
       This is a helper to build a configuration.
 
-      [username] username needed for the login
+      [username] username needed for the login, if not provided, SMTP will be used
+      unauthenticated
 
-      [password] user's password for the login
+      [password] user's password for the login, if not provided, SMTP will be used
+      unauthenticated
 
       [hostname] hostname of the SMTP server
 
       [with_starttls] True if start unencrypted connection and then "promote" *)
   val make
-    :  username:string
-    -> password:string
+    :  username:string option
+    -> password:string option
     -> hostname:string
     -> with_starttls:bool
     -> t

--- a/lib/sendmail_handler.ml
+++ b/lib/sendmail_handler.ml
@@ -37,7 +37,7 @@ let run_with_starttls
     ~hostname
     ?port
     ~domain
-    ~authentication
+    ?authentication
     ~tls_authenticator
     ~from
     ~recipients
@@ -81,7 +81,7 @@ let run_with_starttls
         { ic; oc }
         ctx
         tls
-        ~authentication
+        ?authentication
         ~domain
         from
         recipients
@@ -90,7 +90,7 @@ let run_with_starttls
     Lwt_scheduler.prj fiber)
 ;;
 
-let run ~hostname ?port ~domain ~authentication ~tls_authenticator ~from ~recipients ~mail
+let run ~hostname ?port ~domain ?authentication ~tls_authenticator ~from ~recipients ~mail
   =
   let ( let* ) = Lwt.bind in
   let port =
@@ -113,7 +113,7 @@ let run ~hostname ?port ~domain ~authentication ~tls_authenticator ~from ~recipi
       rdwr
       { ic; oc }
       ctx
-      ~authentication
+      ?authentication
       ~domain
       from
       recipients

--- a/lib/sendmail_handler.mli
+++ b/lib/sendmail_handler.mli
@@ -2,7 +2,7 @@ val run_with_starttls
   :  hostname:'a Domain_name.t
   -> ?port:int
   -> domain:Colombe.Domain.t
-  -> authentication:Sendmail.authentication
+  -> ?authentication:Sendmail.authentication
   -> tls_authenticator:X509.Authenticator.t
   -> from:Colombe.Reverse_path.t
   -> recipients:Colombe.Forward_path.t list
@@ -13,7 +13,7 @@ val run
   :  hostname:'a Domain_name.t
   -> ?port:int
   -> domain:Colombe.Domain.t
-  -> authentication:Sendmail.authentication
+  -> ?authentication:Sendmail.authentication
   -> tls_authenticator:X509.Authenticator.t
   -> from:Colombe.Reverse_path.t
   -> recipients:Colombe.Forward_path.t list

--- a/service-test/test.ml
+++ b/service-test/test.ml
@@ -8,8 +8,8 @@ let get_ethereal_account_details () =
    * below is relative to the location of the executable under _build
    *)
   let json = Yojson.Basic.from_file "../../../ethereal_account.json" in
-  let username = json |> member "username" |> to_string in
-  let password = json |> member "password" |> to_string in
+  let username = json |> member "username" |> to_string |> Option.some in
+  let password = json |> member "password" |> to_string |> Option.some in
   let hostname = json |> member "hostname" |> to_string in
   let port = json |> member "port" |> to_int in
   let with_starttls = json |> member "secure" |> to_bool |> not in
@@ -24,8 +24,8 @@ let get_mailtrap_account_details () =
    * below is relative to the location of the executable under _build
    *)
   let json = Yojson.Basic.from_file "../../../mailtrap_account.json" in
-  let username = json |> member "username" |> to_string in
-  let password = json |> member "password" |> to_string in
+  let username = json |> member "username" |> to_string |> Option.some in
+  let password = json |> member "password" |> to_string |> Option.some in
   let hostname = json |> member "hostname" |> to_string in
   let port = json |> member "port" |> to_int in
   let with_starttls = json |> member "secure" |> to_bool |> not in


### PR DESCRIPTION
The reason for this PR is demand for the unauthenticated SMTP for UZH at the moment.

We can revert these commits once https://github.com/mirage/colombe/issues/60 is merged, if we don't want to allow unauthenticated access inside of `letters`.
