### PR TITLE
refactor backward compatibility

### DIFF
--- a/dune
+++ b/dune
@@ -1,0 +1,6 @@
+(env
+ (dev
+  (flags
+   (:standard -w +A-42-44-45-48-66 -warn-error +A-3))))
+
+(data_only_dirs .git)

--- a/lib/letters.ml
+++ b/lib/letters.ml
@@ -14,7 +14,8 @@ module Config = struct
     ; mechanism : Sendmail.mechanism
     }
 
-  let make ?(mechanism = Sendmail.PLAIN) ~username ~password ~hostname ~with_starttls =
+  let create ?(mechanism = Sendmail.PLAIN) ~username ~password ~hostname ~with_starttls ()
+    =
     let username =
       if String.equal username "" then Option.none else Option.some username
     in
@@ -29,6 +30,10 @@ module Config = struct
     ; ca_certs = Detect
     ; mechanism
     }
+  ;;
+
+  let make ~username ~password ~hostname ~with_starttls =
+    create ~username ~password ~hostname ~with_starttls ()
   ;;
 
   let set_port port config = { config with port }
@@ -162,7 +167,8 @@ let build_email ~from ~recipients ~subject ~body =
         let html = Mt.part ~header:html_headers (stream_of_string html) in
         let header =
           Header.of_list
-            [ Field (Field_name.content_type, Content, multipart_content_alternative) ]
+            Field.
+              [ Field (Field_name.content_type, Content, multipart_content_alternative) ]
         in
         (match boundary with
          | None -> MtMultipart (Mt.multipart ~rng:Mt.rng ~header [ plain; html ])
@@ -200,7 +206,7 @@ let send =
     let authentication : Sendmail.authentication option =
       match c.username, c.password with
       | Some username, Some password ->
-        Some { username; password; mechanism = c.mechanism }
+        Some { Sendmail.username; password; mechanism = c.mechanism }
       | _ -> None
     in
     let port =

--- a/lib/letters.mli
+++ b/lib/letters.mli
@@ -17,9 +17,18 @@ module Config : sig
       [with_starttls] True if start unencrypted connection and then "promote"
 
       [?mechanism] login mechanism used by sendmail (default: PLAIN) *)
-  val make
+  val create
     :  ?mechanism:Sendmail.mechanism
     -> username:string
+    -> password:string
+    -> hostname:string
+    -> with_starttls:bool
+    -> unit
+    -> t
+
+  (** Same as [create] with default mechanism - backwards compatibility *)
+  val make
+    :  username:string
     -> password:string
     -> hostname:string
     -> with_starttls:bool

--- a/test/test.ml
+++ b/test/test.ml
@@ -54,7 +54,30 @@ let test_create_mixed_body_email _ () =
   Lwt.return (print_string message)
 ;;
 
+let test_create_config () =
+  (* check for config compatibility *)
+  let username, password, hostname, with_starttls =
+    "SomeUser", "password", "localhost", true
+  in
+  let (_ : Config.t) = Config.make ~username ~password ~hostname ~with_starttls in
+  let (_ : Config.t) = Config.create ~username ~password ~hostname ~with_starttls () in
+  let (_ : Config.t) =
+    Config.create
+      ~mechanism:Sendmail.LOGIN
+      ~username
+      ~password
+      ~hostname
+      ~with_starttls
+      ()
+  in
+  ()
+;;
+
 let () =
+  let () =
+    Alcotest.(
+      run "model" [ "config", [ test_case "create config" `Quick test_create_config ] ])
+  in
   Lwt_main.run
     (Alcotest_lwt.run
        "Email creation"


### PR DESCRIPTION
- add dune project config, to fail more often
- add test to raise code 5
- refactor for backward compatibility

It wasn't my intention to create an optional argument that cannot be erased.
The added test will raise the error that occurred in the version upgrade PR (https://github.com/ocaml/opam-repository/pull/23039).