### PR TITLE
add reply to field on email creation if needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ create_switch:
 build:
 	opam exec -- dune build @install
 
+.PHONY: watch
+watch:
+	opam exec -- dune build @install --watch
+
 .PHONY: clean
 clean:
 	opam exec -- dune clean

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Letters is a library for creating and sending emails over SMTP using [Lwt](https://github.com/ocsigen/lwt).
 
 ## Table of Contents
+
 * [Use](#use)
   * [Configuration](#configuration)
   * [Building emails](#building-emails)
@@ -20,6 +21,7 @@ Letters is a library for creating and sending emails over SMTP using [Lwt](https
 ## Use
 
 Purpose of the library is to make it easier to send emails when building systems using OCaml. Currently the API consists of three parts:
+
 1. configuration
 2. building email messages
 3. sending email messages
@@ -33,8 +35,9 @@ Keep in mind that this library is in its early days and the API is changing with
 Most simple use case would look something like:
 
 ``` ocaml
-let conf = Config.make ~username:"myuser" ~password:"mypasswd" ~hostname:"smtp.ethereal.email" ~with_starttls:true
+let conf = Config.create ~username:"myuser" ~password:"mypasswd" ~hostname:"smtp.ethereal.email" ~with_starttls:true ()
 ```
+
 This will use port `587`, uses STARTTLS for encryption and tries automatically find CA certificates for verifying server connection.
 
 Port `587` is default when using STARTTLS. If you set `~with_starttls:false`, then the default port will be `465`.
@@ -44,7 +47,7 @@ This library does **not** support SMTP connections without TLS encryption. For T
 If you want to change the server port you can do it with `Config.set_port` (passing `None` causes default port to be used):
 
 ``` ocaml
-let conf = Config.make ~username:"myuser" ~password:"mypasswd" ~hostname:"smtp.ethereal.email" ~with_starttls:true
+let conf = Config.create ~username:"myuser" ~password:"mypasswd" ~hostname:"smtp.ethereal.email" ~with_starttls:true ()
 |> Config.set_port (Some 2525)
 ```
 
@@ -53,21 +56,21 @@ CA certificate auto-detection is done once initially when you call `Letters.send
 To use a CA certificate bundle (each included certificate needs to be PEM encoded):
 
 ``` ocaml
-let conf = Config.make ~username:"myuser" ~password:"mypasswd" ~hostname:"smtp.ethereal.email" ~with_starttls:true
+let conf = Config.create ~username:"myuser" ~password:"mypasswd" ~hostname:"smtp.ethereal.email" ~with_starttls:true ()
 |> Config.set_ca_cert "/etc/ssl/certs/ca-certificates.crt"
 ```
 
 To use a single PEM encoded CA certificate:
 
 ``` ocaml
-let conf = Config.make ~username:"myuser" ~password:"mypasswd" ~hostname:"smtp.ethereal.email" ~with_starttls:true
+let conf = Config.create ~username:"myuser" ~password:"mypasswd" ~hostname:"smtp.ethereal.email" ~with_starttls:true ()
 |> Config.set_ca_cert "/etc/ssl/certs/DST_Root_CA_X3.pem"
 ```
 
 To use all PEM encoded certificate files from a folder:
 
 ``` ocaml
-let conf = Config.make ~username:"myuser" ~password:"mypasswd" ~hostname:"smtp.ethereal.email" ~with_starttls:true
+let conf = Config.create ~username:"myuser" ~password:"mypasswd" ~hostname:"smtp.ethereal.email" ~with_starttls:true ()
 |> Config.set_ca_path "/etc/ssl/certs/"
 ```
 
@@ -76,6 +79,7 @@ let conf = Config.make ~username:"myuser" ~password:"mypasswd" ~hostname:"smtp.e
 Building an email is separated into its own step so that you can use [mrmime](https://opam.ocaml.org/packages/mrmime/) to generate more complex emails when this simplified API does not work for you.
 
 To use our provided API, you can build three kinds of emails:
+
 1. `Plain`, plain text
 2. `Html`, HTML only
 3. `Mixed`, multipart/alternative containing both: plain text and HTML segments
@@ -105,7 +109,7 @@ Regards,
 The Letters team
 |}
   in
-  let mail = build_email ~from:sender ~recipients ~subject ~body in
+  let mail = create_email ~from:sender ~recipients ~subject ~body () in
 ```
 
 Example of building an HTML only email:
@@ -133,7 +137,7 @@ The Letters team
 </p>
 |}
 in
-let mail = build_email ~from:sender ~recipients ~subject ~body in
+let mail = create_email ~from:sender ~recipients ~subject ~body () in
 ```
 
 Example of building an email with plain text and HTML segments:
@@ -169,13 +173,13 @@ Regards,<br>
 The Letters team
 |}
 in
-let mail = build_email ~from:sender ~recipients ~subject ~body:(Mixed (text, html, None)) in
+let mail = create_email ~from:sender ~recipients ~subject ~body:(Mixed (text, html, None)) () in
 ```
 
-`Letters.build_email` returns `result` so you need to map it accordingly:
+`Letters.create_email` returns `result` so you need to map it accordingly:
 
 ``` ocaml
-let mail = build_email ~from:sender ~recipients ~subject ~body:(Mixed (text, html, None)) in
+let mail = create_email ~from:sender ~recipients ~subject ~body:(Mixed (text, html, None)) () in
 match mail with
 | Ok message -> do_something message
 | Error reason -> handle_error reason
@@ -244,12 +248,14 @@ curl -s -d '{ "requestor": "letters", "version": "dev" }' "https://api.nodemaile
 ```
 
 For *mailtrap.io*, you need to create a personal account first and get the API key (for v1 API):
-- [signup](https://mailtrap.io/register/signup?ref=header)
-- click on your name top right and select "My Profile", copy the "Api Token"
+
+* [signup](https://mailtrap.io/register/signup?ref=header)
+* click on your name top right and select "My Profile", copy the "Api Token"
 
 The configuration file you can create with following steps:
-- create environment variable containing your API token: `export MAILTRAP_API_TOKEN=<API token>`
-- run the following one-liner in terminal to create the configuration file:
+
+* create environment variable containing your API token: `export MAILTRAP_API_TOKEN=<API token>`
+* run the following one-liner in terminal to create the configuration file:
 
 ``` shell
 curl -s -H "Api-Token: ${MAILTRAP_API_TOKEN}" "https://mailtrap.io/api/v1/inboxes" | jq '.[0] | { hostname: .domain, port: .smtp_ports[2], secure: false, username: .username, password: .password }' > mailtrap_account.json
@@ -262,13 +268,15 @@ dune build @runtest-all
 ```
 
 Finally review that all emails are correctly received in *ethreal.email*:
-- login to https://ethereal.email/login using credentials from the `ethereal_account.json`
-- check the content of new messages: https://ethereal.email/messages
+
+* login to <https://ethereal.email/login> using credentials from the `ethereal_account.json`
+* check the content of new messages: <https://ethereal.email/messages>
 
 Also check that you can find all emails in the inbox in *mailtrap.io*:
-- login to [mailtrap.io](https://mailtrap.io/signin) using your personal credentials
-- select the first inbox (unless you use another one), from [inboxes](https://mailtrap.io/inboxes)
-- check the content of new messages
+
+* login to [mailtrap.io](https://mailtrap.io/signin) using your personal credentials
+* select the first inbox (unless you use another one), from [inboxes](https://mailtrap.io/inboxes)
+* check the content of new messages
 
 ## Credits
 

--- a/lib/letters.mli
+++ b/lib/letters.mli
@@ -33,6 +33,7 @@ module Config : sig
     -> hostname:string
     -> with_starttls:bool
     -> t
+    [@@deprecated "Replace with [create] function"]
 
   (** Add a port to configuration record
 
@@ -73,6 +74,8 @@ type recipient =
     This function is a helper function to simplify process of building an email with
     `mrmime`. It will return result type and wraps all exceptions into Error
 
+    [reply_to] specific email address to reply to
+
     [from] string representation of the email proved as a `from` field, this can be a
     different email address than the [config.sender].
 
@@ -84,14 +87,27 @@ type recipient =
     or HTML message
 
     Returns [result] indicating if built email is valid or Error if anything failed *)
+val create_email
+  :  ?reply_to:string
+  -> from:string
+  -> recipients:recipient list
+  -> subject:string
+  -> body:body
+  -> unit
+  -> (Mrmime.Mt.t, string) result
+
+(** Build an email using mrmime like [create_email]
+
+    Backwards compatible build function without reply_to *)
 val build_email
   :  from:string
   -> recipients:recipient list
   -> subject:string
   -> body:body
   -> (Mrmime.Mt.t, string) result
+  [@@deprecated "Replace with [create_email] function"]
 
-(** Send the previously generated email
+(** Send the previously created email
 
     This function expects valid configuration, list of recipients and finally a valid
     `mrmime` representation of the email message.

--- a/service-test/test.ml
+++ b/service-test/test.ml
@@ -13,7 +13,7 @@ let get_ethereal_account_details () =
   let hostname = json |> member "hostname" |> to_string in
   let port = json |> member "port" |> to_int in
   let with_starttls = json |> member "secure" |> to_bool |> not in
-  Config.make ~username ~password ~hostname ~with_starttls
+  Config.create ~username ~password ~hostname ~with_starttls ()
   |> Config.set_port (Some port)
   |> Lwt.return
 ;;
@@ -29,7 +29,7 @@ let get_mailtrap_account_details () =
   let hostname = json |> member "hostname" |> to_string in
   let port = json |> member "port" |> to_int in
   let with_starttls = json |> member "secure" |> to_bool |> not in
-  Config.make ~username ~password ~hostname ~with_starttls
+  Config.create ~username ~password ~hostname ~with_starttls ()
   |> Config.set_port (Some port)
   |> Lwt.return
 ;;
@@ -56,7 +56,7 @@ Regards,
 The team
 |}
   in
-  let mail = build_email ~from:sender ~recipients ~subject ~body in
+  let mail = create_email ~from:sender ~recipients ~subject ~body () in
   match mail with
   | Ok message -> send ~config ~sender ~recipients ~message
   | Error reason -> Lwt.fail_with reason
@@ -71,6 +71,7 @@ let test_send_html_email config _ () =
     ; Bcc "dave@example.com"
     ]
   in
+  let reply_to = "reply@example.com" in
   let subject = "HTML only test email" in
   let body =
     Html
@@ -86,7 +87,7 @@ let test_send_html_email config _ () =
 </p>
 |}
   in
-  let mail = build_email ~from:sender ~recipients ~subject ~body in
+  let mail = create_email ~reply_to ~from:sender ~recipients ~subject ~body () in
   match mail with
   | Ok message -> send ~config ~sender ~recipients ~message
   | Error reason -> Lwt.fail_with reason
@@ -127,7 +128,7 @@ The team
 |}
   in
   let mail =
-    build_email ~from:sender ~recipients ~subject ~body:(Mixed (text, html, None))
+    create_email ~from:sender ~recipients ~subject ~body:(Mixed (text, html, None)) ()
   in
   match mail with
   | Ok message -> send ~config ~sender ~recipients ~message
@@ -162,7 +163,7 @@ broken:::  <a href="https://github.com/oxidizing/sihl">Sihl</a>
 |}
   in
   let mail =
-    build_email ~from:sender ~recipients ~subject ~body:(Mixed (text, html, None))
+    create_email ~from:sender ~recipients ~subject ~body:(Mixed (text, html, None)) ()
   in
   match mail with
   | Ok message -> send ~config ~sender ~recipients ~message

--- a/test/test.ml
+++ b/test/test.ml
@@ -16,7 +16,7 @@ let test_create_plain_text_email _ () =
   let recipients = [ To "dave@example.com" ] in
   let subject = "Hello" in
   let body = Plain "Hello Dave" in
-  let mail = build_email ~from:"harry@example.com" ~recipients ~subject ~body in
+  let mail = create_email ~from:"harry@example.com" ~recipients ~subject ~body () in
   let stream =
     match mail with
     | Ok mail -> Mrmime.Mt.to_stream mail
@@ -30,7 +30,7 @@ let test_create_html_email _ () =
   let recipients = [ To "dave@example.com" ] in
   let subject = "Hello" in
   let body = Html "<i>Hello Dave</i>" in
-  let mail = build_email ~from:"harry@example.com" ~recipients ~subject ~body in
+  let mail = create_email ~from:"harry@example.com" ~recipients ~subject ~body () in
   let stream =
     match mail with
     | Ok mail -> Mrmime.Mt.to_stream mail
@@ -44,7 +44,7 @@ let test_create_mixed_body_email _ () =
   let recipients = [ To "dave@example.com" ] in
   let subject = "Hello" in
   let body = Mixed ("Hello Dave", "<i>Hello Dave</i>", Some "blaablaa") in
-  let mail = build_email ~from:"harry@example.com" ~recipients ~subject ~body in
+  let mail = create_email ~from:"harry@example.com" ~recipients ~subject ~body () in
   let stream =
     match mail with
     | Ok mail -> Mrmime.Mt.to_stream mail
@@ -59,7 +59,9 @@ let test_create_config () =
   let username, password, hostname, with_starttls =
     "SomeUser", "password", "localhost", true
   in
-  let (_ : Config.t) = Config.make ~username ~password ~hostname ~with_starttls in
+  let[@warning "-3"] (_ : Config.t) =
+    Config.make ~username ~password ~hostname ~with_starttls
+  in
   let (_ : Config.t) = Config.create ~username ~password ~hostname ~with_starttls () in
   let (_ : Config.t) =
     Config.create


### PR DESCRIPTION
- add the additional Mrmime reply to the header field (optional)
- use `create_email` for the new function
- backward compatible `build_email` function
- add deprecation warnings (showing replaced by function)
- add reply-to address to test
- update and format README.md