### PR TITLE
tls.lwt is now tls-lwt

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -2,21 +2,20 @@
  (name letters)
  (public_name letters)
  (libraries
-   ptime.clock.os
-   lwt
-   lwt.unix
-   tls
-   tls.lwt
-   fpath
-   colombe
-   colombe.emile
-   mrmime
-   sendmail
-   sendmail.starttls
-   ca-certs
- )
-)
+  ptime.clock.os
+  lwt
+  lwt.unix
+  tls
+  tls-lwt
+  fpath
+  colombe
+  colombe.emile
+  mrmime
+  sendmail
+  sendmail.starttls
+  ca-certs))
 
 (env
-  (dev
-    (flags (:standard -w -16))))
+ (dev
+  (flags
+   (:standard -w -16))))


### PR DESCRIPTION
will be needed due to changes here [ocaml/opam-repository#23311](https://github.com/ocaml/opam-repository/pull/23311)